### PR TITLE
Replaced @available with checking NSAppKitVersionNumber

### DIFF
--- a/Development/Source/Platform/Cocoa/E3CocoaDrawContext.mm
+++ b/Development/Source/Platform/Cocoa/E3CocoaDrawContext.mm
@@ -114,7 +114,7 @@ public :
 {
 	// Grab our bounds
 	NSRect viewBounds = _view.bounds;
-	if (@available( macOS 10.15, * ))
+	if (floor( NSAppKitVersionNumber ) >= 1894.0 /*NSAppKitVersionNumber10_15*/)
 	{
 		viewBounds = [_view convertRectToBacking: viewBounds];
 	}
@@ -253,7 +253,7 @@ e3drawcontext_cocoa_get_dimensions(TQ3DrawContextObject theDrawContext, TQ3Area 
 	TQ3CocoaDrawContextData& cocoaData( instanceData->data.cocoaData.theData );
 	NSView* theView = (NSView*) cocoaData.nsView;
 	NSRect	viewBounds = theView.bounds;
-	if (@available( macOS 10.15, * ))
+	if (floor( NSAppKitVersionNumber ) >= 1894.0 /*NSAppKitVersionNumber10_15*/)
 	{
 		viewBounds = [theView convertRectToBacking: viewBounds];
 	}

--- a/Development/Source/Renderers/Common/GLCocoaContext.mm
+++ b/Development/Source/Renderers/Common/GLCocoaContext.mm
@@ -250,7 +250,7 @@ CocoaGLContext::CocoaGLContext(
 				// Get the view bounds from the NSView for the initial gl viewport
 				// and the default draw context pane if it's needed.
 				viewFrame = theView.bounds;
-				if (@available( macOS 10.15, * ))
+				if (floor( NSAppKitVersionNumber ) >= 1894.0 /*NSAppKitVersionNumber10_15*/)
 				{
 					viewFrame = [theView convertRectToBacking: viewFrame];
 				}
@@ -421,7 +421,7 @@ bool	CocoaGLContext::UpdateWindowSize()
 	
 	NSView* theView = (NSView*) nsView;
 	NSRect viewFrame = theView.bounds;
-	if (@available( macOS 10.15, * ))
+	if (floor( NSAppKitVersionNumber ) >= 1894.0 /*NSAppKitVersionNumber10_15*/)
 	{
 		viewFrame = [theView convertRectToBacking: viewFrame];
 	}


### PR DESCRIPTION
This fixes a link error when building quesa with newer Xcode but then using the resulting lib/framework in older Xcode.