### PR TITLE
MeshCorners (crnr), MeshEdges (edge), and UnknownText (uktx)

### DIFF
--- a/SDK/Extras/Textify3DMF/Source/RegisterHandlers.cpp
+++ b/SDK/Extras/Textify3DMF/Source/RegisterHandlers.cpp
@@ -139,6 +139,9 @@
 #include "SpecularMapElement.h"
 #include "TableOfContents.h"
 #include "Reference.h"
+#include "MeshCorners.h"
+#include "MeshEdges.h"
+#include "UnknownText.h"
 
 #include "VertexAttributeSetList.h"
 
@@ -271,4 +274,7 @@ void	RegisterHandlers( Controller* inController )
 	Register( NormalMapElement );
 	Register( TableOfContents );
 	Register( Reference );
+  Register( MeshCorners );
+  Register( MeshEdges );
+  Register( UnknownText );
 }

--- a/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/MeshCorners.cpp
+++ b/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/MeshCorners.cpp
@@ -1,0 +1,60 @@
+/*
+ *  Normal.cpp
+ *  Textify3DMF
+ *
+ *  Created by James Walker on 4/21/12.
+ *  Copyright (c) 2012 James W. Walker.
+ *
+ *  This software is provided 'as-is', without any express or implied warranty.
+ *  In no event will the authors be held liable for any damages arising from the
+ *  use of this software.
+ *
+ *  Permission is granted to anyone to use this software for any purpose,
+ *  including commercial applications, and to alter it and redistribute it
+ *  freely, subject to the following restrictions:
+ *
+ *    1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in a
+ *    product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ *    2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ *    3. This notice may not be removed or altered from any source distribution.
+ *
+ */
+
+#include "MeshCorners.h"
+
+MeshCorners::MeshCorners()
+  : TypeHandler( 'crnr', "MeshCorners" )
+{
+}
+
+void  MeshCorners::Process( size_t inStartOffset,
+                  size_t inEndOffset )
+{
+  //  TODO: DataLengthExceptions
+
+  size_t offset = inStartOffset;
+  
+  Out() << Indent() << Name() << " (\n";
+  int numCorners = FetchUInt32(offset); offset += 4;
+  Out() << Indent(1) << numCorners << " # numCorners\n\n";
+  for (int i = 0; i < numCorners; i++)
+  {
+    int vertexIndex = FetchUInt32(offset); offset += 4;
+    int numFaces = FetchUInt32(offset); offset += 4;
+    Out() <<
+      Indent(1) << "# Corner " << i << "\n" <<
+      Indent(1) << vertexIndex << " # vertexIndex\n" <<
+      Indent(1) << numFaces << " # numFaces\n" << Indent(1);
+    for (int j = 0; j < numFaces; j++)
+    {
+      int faceIndex = FetchUInt32(offset); offset += 4;
+      Out() << faceIndex << ((j + 1 == numFaces) ? " # face indices\n\n" : " ");
+    }
+  }
+  Out() << " )\n";
+}

--- a/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/MeshCorners.h
+++ b/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/MeshCorners.h
@@ -1,0 +1,36 @@
+/*
+ *  Normal.h
+ *  Textify3DMF
+ *
+ *  Created by James Walker on 4/21/12.
+ *  Copyright (c) 2012 James W. Walker.
+ *
+ *  This software is provided 'as-is', without any express or implied warranty.
+ *  In no event will the authors be held liable for any damages arising from the
+ *  use of this software.
+ *
+ *  Permission is granted to anyone to use this software for any purpose,
+ *  including commercial applications, and to alter it and redistribute it
+ *  freely, subject to the following restrictions:
+ *
+ *    1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in a
+ *    product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ *    2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ *    3. This notice may not be removed or altered from any source distribution.
+ *
+ */
+
+
+class MeshCorners : public TypeHandler
+{
+public:
+  MeshCorners();
+  
+  virtual void      Process( size_t inStartOffset,
+                  size_t inEndOffset );
+};

--- a/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/MeshEdges.cpp
+++ b/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/MeshEdges.cpp
@@ -1,0 +1,52 @@
+/*
+ *  Normal.cpp
+ *  Textify3DMF
+ *
+ *  Created by James Walker on 4/21/12.
+ *  Copyright (c) 2012 James W. Walker.
+ *
+ *  This software is provided 'as-is', without any express or implied warranty.
+ *  In no event will the authors be held liable for any damages arising from the
+ *  use of this software.
+ *
+ *  Permission is granted to anyone to use this software for any purpose,
+ *  including commercial applications, and to alter it and redistribute it
+ *  freely, subject to the following restrictions:
+ *
+ *    1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in a
+ *    product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ *    2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ *    3. This notice may not be removed or altered from any source distribution.
+ *
+ */
+
+#include "MeshEdges.h"
+
+MeshEdges::MeshEdges()
+  : TypeHandler( 'edge', "MeshEdges" )
+{
+}
+
+void  MeshEdges::Process( size_t inStartOffset,
+                  size_t inEndOffset )
+{
+  //  TODO: DataLengthExceptions
+
+  size_t offset = inStartOffset;
+  
+  Out() << Indent() << Name() << " (\n";
+  int numEdges = FetchUInt32(offset); offset += 4;
+  Out() << Indent(1) << numEdges << " # numEdges\n";
+  for (int i = 0; i < numEdges; i++)
+  {
+    int v0 = FetchUInt32(offset); offset += 4;
+    int v1 = FetchUInt32(offset); offset += 4;
+    Out() << Indent(1) << v0 << " " << v1 << " # Corner " << i << " vertexIndices\n";
+  }
+  Out() << " )\n";
+}

--- a/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/MeshEdges.h
+++ b/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/MeshEdges.h
@@ -1,0 +1,36 @@
+/*
+ *  Normal.h
+ *  Textify3DMF
+ *
+ *  Created by James Walker on 4/21/12.
+ *  Copyright (c) 2012 James W. Walker.
+ *
+ *  This software is provided 'as-is', without any express or implied warranty.
+ *  In no event will the authors be held liable for any damages arising from the
+ *  use of this software.
+ *
+ *  Permission is granted to anyone to use this software for any purpose,
+ *  including commercial applications, and to alter it and redistribute it
+ *  freely, subject to the following restrictions:
+ *
+ *    1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in a
+ *    product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ *    2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ *    3. This notice may not be removed or altered from any source distribution.
+ *
+ */
+
+
+class MeshEdges : public TypeHandler
+{
+public:
+  MeshEdges();
+  
+  virtual void      Process( size_t inStartOffset,
+                  size_t inEndOffset );
+};

--- a/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/UnknownText.cpp
+++ b/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/UnknownText.cpp
@@ -1,0 +1,109 @@
+/*
+ *  Normal.cpp
+ *  Textify3DMF
+ *
+ *  Created by James Walker on 4/21/12.
+ *  Copyright (c) 2012 James W. Walker.
+ *
+ *  This software is provided 'as-is', without any express or implied warranty.
+ *  In no event will the authors be held liable for any damages arising from the
+ *  use of this software.
+ *
+ *  Permission is granted to anyone to use this software for any purpose,
+ *  including commercial applications, and to alter it and redistribute it
+ *  freely, subject to the following restrictions:
+ *
+ *    1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in a
+ *    product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ *    2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ *    3. This notice may not be removed or altered from any source distribution.
+ *
+ */
+
+#include "UnknownText.h"
+
+UnknownText::UnknownText()
+  : TypeHandler( 'uktx', "UnknownText" )
+{
+}
+
+static std::string QuoteStringFor3DMF( const std::string& inStr )
+{
+  std::string result( 1, '"' );
+  
+  for (std::string::const_iterator i = inStr.begin(); i != inStr.end(); ++i)
+  {
+    char theChar( *i );
+    
+    switch (theChar)
+    {
+      case '"':
+        result += "\\\"";
+        break;
+      
+      case '\t':
+        result += "\\t";
+        break;
+      
+      case '\r':
+        result += "\\r";
+        break;
+      
+      case '\n':
+        result += "\\n";
+        break;
+      
+      case '\\':
+        result += "\\\\";
+        break;
+      
+      default:
+        result += theChar;
+        break;
+    }
+  }
+  
+  result += '"';
+  
+  return result;
+}
+
+void  UnknownText::Process( size_t inStartOffset,
+                  size_t inEndOffset )
+{
+  if (inEndOffset - inStartOffset < 4)
+  {
+    throw DataLengthException( Name(), inStartOffset, inEndOffset, 4 );
+  }
+
+  std::string asciiName;
+  std::string contents;
+  size_t nameBytesConsumed;
+  size_t contentsBytesConsumed;
+  bool didRead = Boss()->FetchString( inStartOffset, inEndOffset, asciiName,
+                                     nameBytesConsumed );
+
+  if (didRead)
+  {
+    didRead = Boss()->FetchString( inStartOffset + nameBytesConsumed, inEndOffset, contents,
+                                  contentsBytesConsumed );
+  }
+  
+  if ( (not didRead) or (nameBytesConsumed + contentsBytesConsumed < inEndOffset - inStartOffset) )
+  {
+    throw DataLengthException( Name(), inStartOffset, inEndOffset,
+      inEndOffset - inStartOffset );
+  }
+  
+  Out() << Indent() << Name() << " (\n";
+  
+  Out() << Indent(1) << QuoteStringFor3DMF( asciiName ) << "\n";
+  Out() << Indent(1) << QuoteStringFor3DMF( contents ) << "\n";
+  
+  Out() << Indent() << ")\n";
+}

--- a/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/UnknownText.h
+++ b/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/UnknownText.h
@@ -1,0 +1,36 @@
+/*
+ *  Normal.h
+ *  Textify3DMF
+ *
+ *  Created by James Walker on 4/21/12.
+ *  Copyright (c) 2012 James W. Walker.
+ *
+ *  This software is provided 'as-is', without any express or implied warranty.
+ *  In no event will the authors be held liable for any damages arising from the
+ *  use of this software.
+ *
+ *  Permission is granted to anyone to use this software for any purpose,
+ *  including commercial applications, and to alter it and redistribute it
+ *  freely, subject to the following restrictions:
+ *
+ *    1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in a
+ *    product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ *    2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ *    3. This notice may not be removed or altered from any source distribution.
+ *
+ */
+
+
+class UnknownText : public TypeHandler
+{
+public:
+  UnknownText();
+  
+  virtual void      Process( size_t inStartOffset,
+                  size_t inEndOffset );
+};

--- a/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/main.cpp
+++ b/SDK/Extras/Textify3DMF/Source/TypeHandlers/Miscellaneous/main.cpp
@@ -1,0 +1,100 @@
+/*
+ *  main.cpp
+ *  Textify3DMF
+ *
+ *  Created by James Walker on 3/26/12.
+ *
+ *  Copyright (c) 2012 James W. Walker.
+ *
+ *  This software is provided 'as-is', without any express or implied warranty.
+ *  In no event will the authors be held liable for any damages arising from the
+ *  use of this software.
+ *
+ *  Permission is granted to anyone to use this software for any purpose,
+ *  including commercial applications, and to alter it and redistribute it
+ *  freely, subject to the following restrictions:
+ *
+ *    1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in a
+ *    product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ *    2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ *    3. This notice may not be removed or altered from any source distribution.
+ *
+ */
+#include "Textify3DMF.h"
+
+#include <iostream>
+#include <cstdio>
+#include <cstring>
+#include <stdint.h>
+#include <vector>
+#include <string>
+
+using namespace std;
+
+int main (int argc, char * const argv[])
+{
+	if ( (argc < 2) || (argc > 3) )
+	{
+		std::cerr << "Usage: Textify3DMF [--skipUnknowns] path.3dmf > outpath.3dmf\n";
+		return 1;
+	}
+	
+	bool skipUnknowns = false;
+	const char* filePath = argv[1];
+	if (argc == 3)
+	{
+		if (std::string(argv[1]) == "--skipUnknowns")
+		{
+			skipUnknowns = true;
+			filePath = argv[2];
+		}
+		else
+		{
+			cerr << "Bad arguments.\n" <<
+					"Textify3DMF [--skipUnknowns] path.3dmf\n";
+			return 1;
+		}
+	}
+
+	FILE* inFile = fopen( filePath, "rb" );
+	if (inFile == NULL)
+	{
+		cerr << "Cannot open input file '" << filePath << "'\n";
+		return 2;
+	}
+
+	fseek( inFile, 0, SEEK_END );
+	long fileLen = ftell( inFile );
+	fseek( inFile, 0, SEEK_SET );
+
+	// Read the whole file into a buffer.
+	vector<uint8_t>	dataBuf( fileLen );
+	uint8_t*	bufStart = &dataBuf[0];
+	size_t	numRead = fread( bufStart, 1, fileLen, inFile );
+
+	if (numRead < fileLen)
+	{
+		cerr << "Only read " << numRead << " bytes out of " << fileLen <<
+			"expected." << endl;
+		return 3;
+	}
+	else
+	{
+		try
+		{
+			Textify3DMF( bufStart, fileLen, skipUnknowns );
+		}
+		catch (...)
+		{
+			cerr << "Exception thrown." << endl;
+			return 4;
+		}
+	}
+
+    return 0;
+}

--- a/SDK/Extras/Textify3DMF/Textify3DMF.xcodeproj/project.pbxproj
+++ b/SDK/Extras/Textify3DMF/Textify3DMF.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3CD762AF2E7F400600BB4422 /* MeshEdges.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3CD762AE2E7F3FFD00BB4422 /* MeshEdges.cpp */; };
+		3CD762B02E7F400600BB4422 /* UnknownText.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3CD762AB2E7F3FFD00BB4422 /* UnknownText.cpp */; };
+		3CD762B12E7F400600BB4422 /* MeshCorners.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3CD762AA2E7F3FFD00BB4422 /* MeshCorners.cpp */; };
 		8DD76F650486A84900D96B5E /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 08FB7796FE84155DC02AAC07 /* main.cpp */; settings = {ATTRIBUTES = (); }; };
 		BE03BAB715260A75008EF142 /* Matrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE03BAB615260A75008EF142 /* Matrix.cpp */; };
 		BE03BAF015260E0F008EF142 /* Line.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE03BAEF15260E0F008EF142 /* Line.cpp */; };
@@ -134,6 +137,12 @@
 
 /* Begin PBXFileReference section */
 		08FB7796FE84155DC02AAC07 /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
+		3CD762A92E7F3FFD00BB4422 /* MeshEdges.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MeshEdges.h; path = Source/TypeHandlers/Miscellaneous/MeshEdges.h; sourceTree = "<group>"; };
+		3CD762AA2E7F3FFD00BB4422 /* MeshCorners.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MeshCorners.cpp; path = Source/TypeHandlers/Miscellaneous/MeshCorners.cpp; sourceTree = "<group>"; };
+		3CD762AB2E7F3FFD00BB4422 /* UnknownText.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = UnknownText.cpp; path = Source/TypeHandlers/Miscellaneous/UnknownText.cpp; sourceTree = "<group>"; };
+		3CD762AC2E7F3FFD00BB4422 /* MeshCorners.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MeshCorners.h; path = Source/TypeHandlers/Miscellaneous/MeshCorners.h; sourceTree = "<group>"; };
+		3CD762AD2E7F3FFD00BB4422 /* UnknownText.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = UnknownText.h; path = Source/TypeHandlers/Miscellaneous/UnknownText.h; sourceTree = "<group>"; };
+		3CD762AE2E7F3FFD00BB4422 /* MeshEdges.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MeshEdges.cpp; path = Source/TypeHandlers/Miscellaneous/MeshEdges.cpp; sourceTree = "<group>"; };
 		8DD76F6C0486A84900D96B5E /* Textify3DMF */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Textify3DMF; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE03BAB515260A75008EF142 /* Matrix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Matrix.h; path = Source/TypeHandlers/Transforms/Matrix.h; sourceTree = "<group>"; };
 		BE03BAB615260A75008EF142 /* Matrix.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Matrix.cpp; path = Source/TypeHandlers/Transforms/Matrix.cpp; sourceTree = "<group>"; };
@@ -705,6 +714,12 @@
 				BE1122B21702634F009B685B /* SpecularMapElement.h */,
 				BE03C1AA15310C54008EF142 /* TableOfContents.cpp */,
 				BE03C1A915310C54008EF142 /* TableOfContents.h */,
+				3CD762AB2E7F3FFD00BB4422 /* UnknownText.cpp */,
+				3CD762AD2E7F3FFD00BB4422 /* UnknownText.h */,
+				3CD762AA2E7F3FFD00BB4422 /* MeshCorners.cpp */,
+				3CD762AC2E7F3FFD00BB4422 /* MeshCorners.h */,
+				3CD762AE2E7F3FFD00BB4422 /* MeshEdges.cpp */,
+				3CD762A92E7F3FFD00BB4422 /* MeshEdges.h */,
 			);
 			name = Miscellaneous;
 			sourceTree = "<group>";
@@ -812,6 +827,7 @@
 				BE03BBCC1526D9E4008EF142 /* DiffuseColor.cpp in Sources */,
 				BE03BC1B15276705008EF142 /* TextureShader.cpp in Sources */,
 				BE03BC27152767DF008EF142 /* GenericRenderer.cpp in Sources */,
+				3CD762B12E7F400600BB4422 /* MeshCorners.cpp in Sources */,
 				BE03BC2E15276864008EF142 /* BottomCapAttributeSet.cpp in Sources */,
 				BE03BC3715276941008EF142 /* TopCapAttributeSet.cpp in Sources */,
 				BE03BC401527699F008EF142 /* FaceCapAttributeSet.cpp in Sources */,
@@ -830,6 +846,7 @@
 				BE03BDE21528BDBE008EF142 /* Rotate.cpp in Sources */,
 				BE03BDFC1528C07B008EF142 /* Caps.cpp in Sources */,
 				BE03BE111528D678008EF142 /* Ellipsoid.cpp in Sources */,
+				3CD762B02E7F400600BB4422 /* UnknownText.cpp in Sources */,
 				BE03BE1E1528E05E008EF142 /* Torus.cpp in Sources */,
 				BE03BE311528E1B5008EF142 /* Cone.cpp in Sources */,
 				BE03BE7615292870008EF142 /* EndGroup.cpp in Sources */,
@@ -862,6 +879,7 @@
 				BE03C54E1539DC83008EF142 /* BackfacingStyle.cpp in Sources */,
 				BE03C5831539E5BD008EF142 /* OrientationStyle.cpp in Sources */,
 				BE03C59C153A31D5008EF142 /* AntialiasStyle.cpp in Sources */,
+				3CD762AF2E7F400600BB4422 /* MeshEdges.cpp in Sources */,
 				BE03C5B1153A3B28008EF142 /* FogStyle.cpp in Sources */,
 				BE03C5C3153A3F33008EF142 /* ShadingUV.cpp in Sources */,
 				BE03C5EF153A3FB0008EF142 /* SurfaceUV.cpp in Sources */,


### PR DESCRIPTION
Hi stranger!

I'm using `Textify3DMF` to hopefully convert some old 3DMF files from binary to text, and eventually to GLB for my personal use. The latest version of the tool reports that it doesn't handle `crnr` or `uktx`, which are all over my files.

Using this [useful but incorrectly named reference](https://paulbourke.net/dataformats/qd3dformat/qd3d.html) of the format, I learned of `MeshCorners`, `UnknownText`, and `MeshEdges` (`edge`). So I've added support for these in a branch, and my build now successfully handles these types.

That said, I haven't put any data length checks into `MeshCorners` or `MeshEdges`, and I have no `MeshEdges` of my own to test. All in all, this is a draft PR to hand off what I did to you in case you want it.

Have a wonderful day!